### PR TITLE
Clicking last page in pagination reverts to first page

### DIFF
--- a/src/app/badge/badge-list/badge-list.component.ts
+++ b/src/app/badge/badge-list/badge-list.component.ts
@@ -126,10 +126,6 @@ export class BadgeListComponent implements OnInit {
 
         this.totalItems = badges.length;
 
-        if (this._page * this.itemsPerPage > this.totalItems) {
-            this._page = 1;
-        }
-
         badges = this.pagePipe.transform(badges, this._page, this.itemsPerPage);
 
         this.badges = badges;

--- a/src/app/character/character-badge-checklist/character-badge-checklist.component.ts
+++ b/src/app/character/character-badge-checklist/character-badge-checklist.component.ts
@@ -138,10 +138,6 @@ export class CharacterBadgeChecklistComponent implements OnInit {
 
         this.totalItems = badges.length;
 
-        if (this._page * this.itemsPerPage > this.totalItems) {
-            this._page = 1;
-        }
-
         badges = this.pagePipe.transform(badges, this._page, this.itemsPerPage);
 
         this.badges = badges;


### PR DESCRIPTION
Fixes for #17 

I removed 

`  if (this._page * this.itemsPerPage > this.totalItems) {
            this._page = 1;
        }`

If the page is at 4 and it's multiplied by 500, it exceeds the total items. I believe this is causing the page to revert to 1. 