### PR TITLE
Fix issue that caused logo not to load once deployed

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -27,7 +27,7 @@
 
     <section class="row my-5">
         <div class="col-12 col-md-6 col-lg-4 order-1 order-md-2 mb-5 mb-md-0">
-            <img src="/assets/badger_opt.svg" class="logo-large img-fluid mx-auto d-block" alt="Badger Logo"/>
+            <img src="./assets/badger_opt.svg" class="logo-large img-fluid mx-auto d-block" alt="Badger Logo"/>
         </div>
         <div class="col-12 col-md-6 col-lg-6 offset-lg-1 order-2 order-md-1">
             <h3>What is Badger?</h3>

--- a/src/app/main-nav/main-nav.component.html
+++ b/src/app/main-nav/main-nav.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-primary">
     <a class="navbar-brand d-flex align-middle" routerLink="/">
-        <img alt="Badger" src="/assets/badger_opt.svg">
+        <img alt="Badger" src="./assets/badger_opt.svg">
         Badger
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavContent" aria-controls="mainNavContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
GitHub pages puts everything in a sub-directory and that was messing with the relative image links.